### PR TITLE
Track referee key for event logging

### DIFF
--- a/youtube_sports_logger.py
+++ b/youtube_sports_logger.py
@@ -23,6 +23,8 @@ st.text_input("Referee for D key", key="referee_d")
 
 if "current_referee" not in st.session_state:
     st.session_state["current_referee"] = ""
+if "ref_key" not in st.session_state:
+    st.session_state["ref_key"] = ""
 
 key_pressed = st_javascript(
     """
@@ -40,6 +42,7 @@ if (!window.refKeyListener) {
 )
 
 if key_pressed:
+    st.session_state["ref_key"] = key_pressed
     mapping = {
         "a": st.session_state.get("referee_a", ""),
         "s": st.session_state.get("referee_s", ""),
@@ -97,16 +100,22 @@ formatted_time = format_seconds(current_seconds)
 st.markdown(f"**Current Video Time:** {formatted_time}")
 
 if st.button("Log Event"):
-    selected_event = event_type  # preserve the exact selected value
-    st.session_state.event_log.append(
-        {
-            "Timestamp": formatted_time,
-            "Event": selected_event,
-            "Description": description,
-            "Referee": st.session_state.get("current_referee", ""),
-        }
-    )
-    st.success("Event logged!")
+    if not st.session_state.get("ref_key"):
+        st.warning("Press A, S, or D to select a referee before logging.")
+    else:
+        selected_event = event_type  # preserve the exact selected value
+        referee_name = st.session_state.get(
+            f"referee_{st.session_state['ref_key']}", ""
+        )
+        st.session_state.event_log.append(
+            {
+                "Timestamp": formatted_time,
+                "Event": selected_event,
+                "Description": description,
+                "Referee": referee_name,
+            }
+        )
+        st.success("Event logged!")
 
 # Display and export table
 st.markdown("---")


### PR DESCRIPTION
## Summary
- track last referee key press and store it in session state
- use stored key to derive referee name when logging an event
- prevent logging events without a selected referee

## Testing
- `python -m py_compile youtube_sports_logger.py`
- `python - <<'PY'
session_state = {
    'referee_a': 'Alice',
    'referee_s': 'Sam',
    'referee_d': 'Dan',
    'ref_key': 's',
    'event_log': []
}
formatted_time = '00:01:00'
selected_event = 'Try Scored'
description = 'desc'
referee_name = session_state.get(f"referee_{session_state['ref_key']}", "")
session_state['event_log'].append({
    'Timestamp': formatted_time,
    'Event': selected_event,
    'Description': description,
    'Referee': referee_name,
})
print(session_state['event_log'])
PY`

------
https://chatgpt.com/codex/tasks/task_b_6892230736748321bf1781585a8c64af