### PR TITLE
Replace JS hotkeys with streamlit-keypress component

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 pytube
 streamlit-player
 streamlit-javascript
+streamlit-keypress

--- a/touch_ref_game_logger.py
+++ b/touch_ref_game_logger.py
@@ -3,6 +3,7 @@ import pandas as pd
 from pytube import YouTube
 from streamlit_player import st_player
 from streamlit_javascript import st_javascript
+from streamlit_keypress import key_press_events
 
 
 def format_seconds(total_seconds: float) -> str:
@@ -95,8 +96,8 @@ if "current_referee" not in st.session_state:
     st.session_state["current_referee"] = ""
 if "ref_key" not in st.session_state:
     st.session_state["ref_key"] = ""
-if "last_event" not in st.session_state:
-    st.session_state["last_event"] = ""
+if "last_key" not in st.session_state:
+    st.session_state["last_key"] = ""
 
 ref_map = {
     "a": st.session_state.get("referee_a", ""),
@@ -110,30 +111,7 @@ if "event_log" not in st.session_state:
 
 
 # Global key listener for referee and event hotkeys
-key_pressed = st_javascript(
-    """
-const root = window.parent || window;
-if (!root.globalKeyListener) {
-    const handler = (e) => {
-        let key = e.key || e.keyCode;
-        if (typeof key === 'string') {
-            key = key.toLowerCase();
-        } else {
-            key = String.fromCharCode(key).toLowerCase();
-        }
-        if (['a','s','d','1','2','3','4','5','6','7','8','9'].includes(key)) {
-            e.preventDefault();
-            const event = `${key}:${Date.now()}`;
-            Streamlit.setComponentValue(event);
-        }
-    };
-    root.document.addEventListener('keydown', handler, true);
-    root.globalKeyListener = true;
-main
-}
-""",
-    key="global_key_listener",
-)
+key_pressed = key_press_events()
 
 
 def log_event(event_name: str) -> None:
@@ -157,9 +135,9 @@ def log_event(event_name: str) -> None:
 
 
 # Handle hotkeys
-if key_pressed and key_pressed != st.session_state.get("last_event"):
-    st.session_state["last_event"] = key_pressed
-    key_val = key_pressed.split(":", 1)[0]
+if key_pressed and key_pressed != st.session_state.get("last_key"):
+    st.session_state["last_key"] = key_pressed
+    key_val = key_pressed.lower()
     if key_val in ["a", "s", "d"]:
         st.session_state["ref_key"] = key_val
         st.session_state["current_referee"] = ref_map.get(key_val, "")


### PR DESCRIPTION
## Summary
- Switch hotkey handling to streamlit-keypress component
- Track last key press in session state to avoid duplicate events
- Declare streamlit-keypress dependency

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile touch_ref_game_logger.py`


------
https://chatgpt.com/codex/tasks/task_b_6894dd93c53c8321953b5eebf1ecc483