### PR TITLE
Replace JS hotkeys with streamlit-keypress component

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 pytube
 streamlit-player
 streamlit-javascript
+streamlit-keypress


### PR DESCRIPTION
## Summary
- Switch hotkey handling to streamlit-keypress component
- Track last key press in session state to avoid duplicate events
- Map event hotkeys to digits 1–0 and add an “Other” event
- Declare streamlit-keypress dependency

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile touch_ref_game_logger.py`


------
https://chatgpt.com/codex/tasks/task_b_6894dd93c53c8321953b5eebf1ecc483