### PR TITLE
Normalize streamlit-keypress hotkey events to avoid crashes

### DIFF
--- a/touch_ref_game_logger.py
+++ b/touch_ref_game_logger.py
@@ -121,7 +121,13 @@ if "event_log" not in st.session_state:
 
 
 # Global key listener for referee and event hotkeys
-key_pressed = key_press_events()
+# ``streamlit-keypress`` may return either a raw string (older versions)
+# or a mapping with a ``key`` entry (newer versions). Normalize this so
+# the rest of the app can always work with a simple string.
+key_event = key_press_events()
+key_pressed = (
+    key_event.get("key") if isinstance(key_event, dict) else key_event
+)
 
 
 def log_event(event_name: str) -> None:
@@ -145,7 +151,7 @@ def log_event(event_name: str) -> None:
 
 
 # Handle hotkeys
-if key_pressed and key_pressed != st.session_state.get("last_key"):
+if isinstance(key_pressed, str) and key_pressed != st.session_state.get("last_key"):
     st.session_state["last_key"] = key_pressed
     key_val = key_pressed.lower()
     # Preserve the current playback time so the video resumes after rerun


### PR DESCRIPTION
## Summary
- Normalize `streamlit-keypress` event output so that both string and dict formats are handled
- Guard hotkey handler to only process string inputs

## Testing
- `python -m py_compile touch_ref_game_logger.py`


------
https://chatgpt.com/codex/tasks/task_b_68b35500849c8321ab128743819e627a